### PR TITLE
Updated binpack projects

### DIFF
--- a/makefiles/curl.mk
+++ b/makefiles/curl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += curl
-CURL_VERSION := 136.60.4
+CURL_VERSION := 136.80.2
 
 curl-setup: setup
 	$(call GITHUB_ARCHIVE,apple-oss-distributions,curl,$(CURL_VERSION),curl-$(CURL_VERSION))

--- a/makefiles/dropbear.mk
+++ b/makefiles/dropbear.mk
@@ -39,6 +39,8 @@ dropbear: dropbear-setup
 	$(LN_S) dropbearmulti $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dropbearconvert
 	$(LN_S) dropbearmulti $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/dropbearkey
 	$(LN_S) dropbearmulti $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/scp
+	# ssh is just an alias for dbclient
+	$(LN_S) dropbearmulti $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/ssh
 	$(LN_S) ../bin/dropbearmulti $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/sbin/dropbear
 	mkdir -p $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/
 	cp $(BUILD_ROOT)/dropbear.plist $(BUILD_STAGE)/dropbear/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/share/dropbear.plist.example

--- a/makefiles/dropbear.mk
+++ b/makefiles/dropbear.mk
@@ -3,10 +3,10 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS      += dropbear
-DROPBEAR_VERSION := 2020.81
+DROPBEAR_VERSION := 2022.83
 
 dropbear-setup: setup
-	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/mkj/dropbear/archive/DROPBEAR_2020.81.tar.gz)
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/mkj/dropbear/archive/DROPBEAR_$(DROPBEAR_VERSION).tar.gz)
 	$(call EXTRACT_TAR,DROPBEAR_$(DROPBEAR_VERSION).tar.gz,dropbear-DROPBEAR_$(DROPBEAR_VERSION),dropbear)
 	$(call DO_PATCH,dropbear,dropbear,-p1)
 	[ ! -e $(BUILD_WORK)/dropbear/dropbear-overrides.patch.done ] && patch -p1 -d $(BUILD_WORK)/dropbear < $(BUILD_ROOT)/patches/dropbear-overrides.patch && touch $(BUILD_WORK)/dropbear/dropbear-overrides.patch.done

--- a/makefiles/kext-tools.mk
+++ b/makefiles/kext-tools.mk
@@ -5,7 +5,7 @@ endif
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 
 SUBPROJECTS        += kext-tools
-KEXT_TOOLS_VERSION := 716
+KEXT_TOOLS_VERSION := 721
 
 KEXT_TOOLS_CFLAGS := kext_tools_util.o Shims.o -framework IOKit -framework CoreFoundation -DPRIVATE -D__OS_EXPOSE_INTERNALS__ -DEMBEDDED_HOST
 

--- a/makefiles/ldid.mk
+++ b/makefiles/ldid.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += ldid
-LDID_VERSION := 2.1.5-procursus6
+LDID_VERSION := 2.1.5-procursus7
 
 ldid-setup: setup
 	$(call GITHUB_ARCHIVE,ProcursusTeam,ldid,$(LDID_VERSION),v$(LDID_VERSION))

--- a/makefiles/less.mk
+++ b/makefiles/less.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS  += less
-LESS_VERSION := 590
+LESS_VERSION := 608
 
 less-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),http://www.greenwoodsoftware.com/less/less-$(LESS_VERSION).tar.gz)

--- a/makefiles/libmd.mk
+++ b/makefiles/libmd.mk
@@ -1,0 +1,28 @@
+ifneq ($(PROCURSUS),1)
+$(error Use the main Makefile)
+endif
+
+SUBPROJECTS   += libmd
+LIBMD_VERSION := 1.0.4
+DEB_LIBMD_V   ?= $(LIBMD_VERSION)
+
+libmd-setup: setup
+	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://archive.hadrons.org/software/libmd/libmd-$(LIBMD_VERSION).tar.xz)
+	$(call EXTRACT_TAR,libmd-$(LIBMD_VERSION).tar.xz,libmd-$(LIBMD_VERSION),libmd)
+	sed -i 's|_MSC_VER|__APPLE__|' $(BUILD_WORK)/libmd/src/local-link.h
+
+ifneq ($(wildcard $(BUILD_WORK)/libmd/.build_complete),)
+libmd:
+	@echo "Using previously built libmd."
+else
+libmd: libmd-setup
+	cd $(BUILD_WORK)/libmd && ./configure -C \
+		$(DEFAULT_CONFIGURE_FLAGS) \
+		--disable-shared
+	+$(MAKE) -C $(BUILD_WORK)/libmd
+	+$(MAKE) -C $(BUILD_WORK)/libmd install \
+		DESTDIR=$(BUILD_STAGE)/libmd
+	$(call AFTER_BUILD,copy)
+endif
+
+.PHONY: libmd

--- a/makefiles/libressl.mk
+++ b/makefiles/libressl.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS       += libressl
-LIBRESSL_VERSION  := 3.6.1
+LIBRESSL_VERSION  := 3.7.0
 
 libressl-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$(LIBRESSL_VERSION).tar.gz{$(comma).asc})

--- a/makefiles/libxcrypt.mk
+++ b/makefiles/libxcrypt.mk
@@ -5,7 +5,7 @@ endif
 ifeq (,$(findstring darwin,$(MEMO_TARGET)))
 
 STRAPPROJECTS     += libxcrypt
-LIBXCRYPT_VERSION := 4.4.27
+LIBXCRYPT_VERSION := 4.4.33
 
 libxcrypt-setup: setup
 	$(call GITHUB_ARCHIVE,besser82,libxcrypt,$(LIBXCRYPT_VERSION),v$(LIBXCRYPT_VERSION))

--- a/makefiles/ncurses.mk
+++ b/makefiles/ncurses.mk
@@ -22,10 +22,10 @@ ncurses: ncurses-setup
 	sh progs/MKtermsort.sh awk include/Caps > progs/termsort.c; \
 	echo -e '#define PROG_CAPTOINFO "captoinfo"\n#define PROG_INFOTOCAP "infotocap"\n#define PROG_RESET "reset"\n#define PROG_INIT "init"\n' > progs/transform.h; \
 	for tool in toe tput tset; do \
-		$(CC) $(CFLAGS) $(LDFLAGS) -D_XOPEN_SOURCE_EXTENDED -Iinclude -Iprogs -lncurses progs/$${tool}.c -o $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/$$tool; \
+		$(CC) $(CFLAGS) $(LDFLAGS) -Wno-error-implicit-function-declaration -D_XOPEN_SOURCE_EXTENDED -Iinclude -Iprogs -lncurses progs/$${tool}.c -o $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/$$tool; \
 	done; \
 	for tool in clear infocmp tic; do \
-		$(CC) $(CFLAGS) $(LDFLAGS) -D_XOPEN_SOURCE_EXTENDED -Iinclude -Iprogs -lncurses progs/dump_entry.c progs/$${tool}.c -o $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/$$tool; \
+		$(CC) $(CFLAGS) $(LDFLAGS) -Wno-error-implicit-function-declaration -D_XOPEN_SOURCE_EXTENDED -Iinclude -Iprogs -lncurses progs/dump_entry.c progs/$${tool}.c -o $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/$$tool; \
 	done
 	$(LN_S) tset $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/reset
 	$(LN_S) tic $(BUILD_STAGE)/ncurses/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)/bin/captoinfo

--- a/makefiles/plutil.mk
+++ b/makefiles/plutil.mk
@@ -8,7 +8,7 @@ PLUTIL_VERSION  := 0.2.2
 plutil-setup: setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/Diatrus/plutil/releases/download/v$(PLUTIL_VERSION)/plutil-$(PLUTIL_VERSION).tar.xz)
 	$(call EXTRACT_TAR,plutil-$(PLUTIL_VERSION).tar.xz,plutil-$(PLUTIL_VERSION),plutil)
-	sed -i '/ldid/d' $(BUILD_WORK)/plutil/Makefile
+	sed -i '/LDID/d' $(BUILD_WORK)/plutil/Makefile
 
 ifneq ($(wildcard $(BUILD_WORK)/plutil/.build_complete),)
 plutil:

--- a/makefiles/trustcache.mk
+++ b/makefiles/trustcache.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 SUBPROJECTS         += trustcache
-TRUSTCACHE_VERSION  := 1.0
+TRUSTCACHE_VERSION  := 2.0
 
 trustcache-setup: setup
 	$(call GITHUB_ARCHIVE,CRKatri,trustcache,$(TRUSTCACHE_VERSION),v$(TRUSTCACHE_VERSION))
@@ -13,7 +13,7 @@ ifneq ($(wildcard $(BUILD_WORK)/trustcache/.build_complete),)
 trustcache:
 	@echo "Using previously built trustcache."
 else
-trustcache: trustcache-setup
+trustcache: trustcache-setup libmd
 	+$(MAKE) -C $(BUILD_WORK)/trustcache install \
 		PREFIX="$(BUILD_STAGE)/trustcache/$(MEMO_PREFIX)$(MEMO_SUB_PREFIX)"
 	$(call AFTER_BUILD)

--- a/makefiles/vim.mk
+++ b/makefiles/vim.mk
@@ -4,7 +4,7 @@ endif
 
 SUBPROJECTS += vim
 # Per homebrew, vim should only be updated every 50 releases on multiples of 50
-VIM_VERSION := 8.2.1800
+VIM_VERSION := 9.0.1350
 
 vim-setup: setup binpack-setup
 	$(call GITHUB_ARCHIVE,vim,vim,$(VIM_VERSION),v$(VIM_VERSION))

--- a/makefiles/zstd.mk
+++ b/makefiles/zstd.mk
@@ -3,7 +3,7 @@ $(error Use the main Makefile)
 endif
 
 STRAPPROJECTS += zstd
-ZSTD_VERSION  := 1.5.2
+ZSTD_VERSION  := 1.5.4
 
 zstd-setup: binpack-setup
 	$(call DOWNLOAD_FILES,$(BUILD_SOURCE),https://github.com/facebook/zstd/releases/download/v$(ZSTD_VERSION)/zstd-$(ZSTD_VERSION).tar.gz{$(comma).sig$(comma).sha256})

--- a/patches/dropbear-overrides.patch
+++ b/patches/dropbear-overrides.patch
@@ -1,6 +1,18 @@
+diff -urN a/common-session.c b/common-session.c
+--- a/common-session.c	2022-11-14 11:15:12
++++ b/common-session.c	2023-04-01 13:41:46
+@@ -609,6 +609,8 @@
+ }
+ 
+ const char* get_user_shell() {
++	if (svr_opts.shell != NULL)
++		return svr_opts.shell;
+ 	/* an empty shell should be interpreted as "/bin/sh" */
+ 	if (ses.authstate.pw_shell[0] == '\0') {
+ 		return "/bin/sh";
 diff -urN a/runopts.h b/runopts.h
 --- a/runopts.h	2022-11-14 11:15:12
-+++ b/runopts.h	2023-02-27 13:10:11
++++ b/runopts.h	2023-04-01 13:39:56
 @@ -135,6 +135,8 @@
  	/* points into pubkey_plugin */
  	char *pubkey_plugin_options;
@@ -12,7 +24,7 @@ diff -urN a/runopts.h b/runopts.h
  
 diff -urN a/svr-chansession.c b/svr-chansession.c
 --- a/svr-chansession.c	2022-11-14 11:15:12
-+++ b/svr-chansession.c	2023-02-27 13:10:21
++++ b/svr-chansession.c	2023-04-01 13:49:55
 @@ -1012,7 +1012,9 @@
  	addnewvar("LOGNAME", ses.authstate.pw_name);
  	addnewvar("HOME", ses.authstate.pw_dir);
@@ -24,17 +36,19 @@ diff -urN a/svr-chansession.c b/svr-chansession.c
  		addnewvar("PATH", DEFAULT_ROOT_PATH);
  	} else {
  		addnewvar("PATH", DEFAULT_PATH);
-@@ -1021,6 +1023,7 @@
+@@ -1020,7 +1022,8 @@
+ 	if (cp != NULL) {
  		addnewvar("LANG", cp);
  		m_free(cp);
- 	}	
+-	}	
++	}
 +
  	if (chansess->term != NULL) {
  		addnewvar("TERM", chansess->term);
  	}
 diff -urN a/svr-runopts.c b/svr-runopts.c
 --- a/svr-runopts.c	2022-11-14 11:15:12
-+++ b/svr-runopts.c	2023-02-27 13:10:03
++++ b/svr-runopts.c	2023-04-01 13:39:56
 @@ -178,6 +178,8 @@
          svr_opts.pubkey_plugin = NULL;
          svr_opts.pubkey_plugin_options = NULL;

--- a/patches/dropbear-overrides.patch
+++ b/patches/dropbear-overrides.patch
@@ -1,73 +1,59 @@
-diff --color -urN dropbear-DROPBEAR_2020.81/common-session.c dropbear/common-session.c
---- dropbear-DROPBEAR_2020.81/common-session.c	2020-10-29 13:35:50.000000000 +0000
-+++ dropbear/common-session.c	2022-02-25 16:25:56.502334472 +0000
-@@ -610,6 +610,8 @@
- }
- 
- const char* get_user_shell() {
-+	if (svr_opts.shell != NULL)
-+		return svr_opts.shell;
- 	/* an empty shell should be interpreted as "/bin/sh" */
- 	if (ses.authstate.pw_shell[0] == '\0') {
- 		return "/bin/sh";
-diff --color -urN dropbear-DROPBEAR_2020.81/runopts.h dropbear/runopts.h
---- dropbear-DROPBEAR_2020.81/runopts.h	2020-10-29 13:35:50.000000000 +0000
-+++ dropbear/runopts.h	2022-02-25 16:26:40.404943824 +0000
-@@ -129,6 +129,9 @@
-         char *pubkey_plugin;
-         char *pubkey_plugin_options;
+diff -urN a/runopts.h b/runopts.h
+--- a/runopts.h	2022-11-14 11:15:12
++++ b/runopts.h	2023-02-27 13:10:11
+@@ -135,6 +135,8 @@
+ 	/* points into pubkey_plugin */
+ 	char *pubkey_plugin_options;
  #endif
 +	char *shell;
 +	char *path;
-+	char *terminfo;
  
- } svr_runopts;
+ 	int pass_on_env;
  
-diff --color -urN dropbear-DROPBEAR_2020.81/svr-chansession.c dropbear/svr-chansession.c
---- dropbear-DROPBEAR_2020.81/svr-chansession.c	2020-10-29 13:35:50.000000000 +0000
-+++ dropbear/svr-chansession.c	2022-02-25 16:27:25.929577914 +0000
-@@ -981,7 +981,14 @@
+diff -urN a/svr-chansession.c b/svr-chansession.c
+--- a/svr-chansession.c	2022-11-14 11:15:12
++++ b/svr-chansession.c	2023-02-27 13:10:21
+@@ -1012,7 +1012,9 @@
  	addnewvar("LOGNAME", ses.authstate.pw_name);
  	addnewvar("HOME", ses.authstate.pw_dir);
  	addnewvar("SHELL", get_user_shell());
--	addnewvar("PATH", DEFAULT_PATH);
-+	if (svr_opts.path == NULL)
-+		addnewvar("PATH", DEFAULT_PATH);
-+	else
+-	if (getuid() == 0) {
++	if (svr_opts.path != NULL) {
 +		addnewvar("PATH", svr_opts.path);
-+
-+	if (svr_opts.terminfo != NULL)
-+		addnewvar("TERMINFO", svr_opts.terminfo);
++	} else if (getuid() == 0) {
+ 		addnewvar("PATH", DEFAULT_ROOT_PATH);
+ 	} else {
+ 		addnewvar("PATH", DEFAULT_PATH);
+@@ -1021,6 +1023,7 @@
+ 		addnewvar("LANG", cp);
+ 		m_free(cp);
+ 	}	
 +
  	if (chansess->term != NULL) {
  		addnewvar("TERM", chansess->term);
  	}
-diff --color -urN dropbear-DROPBEAR_2020.81/svr-runopts.c dropbear/svr-runopts.c
---- dropbear-DROPBEAR_2020.81/svr-runopts.c	2020-10-29 13:35:50.000000000 +0000
-+++ dropbear/svr-runopts.c	2022-02-25 16:28:37.173908177 +0000
-@@ -173,6 +173,9 @@
+diff -urN a/svr-runopts.c b/svr-runopts.c
+--- a/svr-runopts.c	2022-11-14 11:15:12
++++ b/svr-runopts.c	2023-02-27 13:10:03
+@@ -178,6 +178,8 @@
          svr_opts.pubkey_plugin = NULL;
          svr_opts.pubkey_plugin_options = NULL;
  #endif
 +	svr_opts.shell = NULL;
 +	svr_opts.path = NULL;
-+	svr_opts.terminfo = NULL;
+ 	svr_opts.pass_on_env = 0;
+ 	svr_opts.reexec_childpipe = -1;
  
- #ifndef DISABLE_ZLIB
- 	opts.compress_mode = DROPBEAR_COMPRESS_DELAYED;
-@@ -305,6 +308,15 @@
- 					print_version();
- 					exit(EXIT_SUCCESS);
+@@ -328,6 +330,12 @@
  					break;
+ 				case 'z':
+ 					opts.disable_ip_tos = 1;
++					break;
 +				case 'S':
 +					next = &svr_opts.shell;
 +					break;
 +				case 'H':
 +					next = &svr_opts.path;
-+					break;
-+				case 't':
-+					next = &svr_opts.terminfo;
-+					break;
+ 					break;
  				default:
  					fprintf(stderr, "Invalid option -%c\n", c);
- 					printhelp(argv[0]);


### PR DESCRIPTION
the `-t` option in the dropbear patch has been removed because now upstream also have a `-t` option (but does a different thing) and the original `-t` option isn't really needed anyways.